### PR TITLE
Fix Cosine with Warmup Scheduler

### DIFF
--- a/src/fjformer/optimizers/adafactor.py
+++ b/src/fjformer/optimizers/adafactor.py
@@ -210,6 +210,7 @@ def get_adafactor_with_cosine_scheduler(
 def get_adafactor_with_warm_up_cosine_scheduler(
         steps: int,
         learning_rate=5e-5,
+        learning_rate_end=1e-5,
         weight_decay=1e-1,
         min_dim_size_to_factor: int = 128,
         decay_rate: float = 0.8,
@@ -230,6 +231,7 @@ def get_adafactor_with_warm_up_cosine_scheduler(
 
     :param steps:
     :param learning_rate:
+    :param learning_rate_end:
     :param weight_decay:
     :param min_dim_size_to_factor:
     :param decay_rate:
@@ -252,7 +254,7 @@ def get_adafactor_with_warm_up_cosine_scheduler(
         peak_value=learning_rate,
         warmup_steps=warmup_steps,
         decay_steps=steps,
-        end_value=learning_rate,
+        end_value=learning_rate_end,
         exponent=exponent
     )
     tx = optax.chain(

--- a/src/fjformer/optimizers/adafactor.py
+++ b/src/fjformer/optimizers/adafactor.py
@@ -223,7 +223,8 @@ def get_adafactor_with_warm_up_cosine_scheduler(
         factored: bool = True,
         exponent: float = 1.0,
         weight_decay_mask=None,
-        gradient_accumulation_steps: int = 1
+        gradient_accumulation_steps: int = 1,
+        warmup_steps: int = 500,
 ):
     """
 
@@ -243,13 +244,14 @@ def get_adafactor_with_warm_up_cosine_scheduler(
     :param exponent:
     :param weight_decay_mask:
     :param gradient_accumulation_steps:
+    :param warmup_steps:
     :return:
     """
     scheduler = optax.warmup_cosine_decay_schedule(
         init_value=0.5e-7,
         peak_value=learning_rate,
-        warmup_steps=steps,
-        decay_steps=steps + 1,
+        warmup_steps=warmup_steps,
+        decay_steps=steps,
         end_value=learning_rate,
         exponent=exponent
     )

--- a/src/fjformer/optimizers/adamw.py
+++ b/src/fjformer/optimizers/adamw.py
@@ -177,6 +177,7 @@ def get_adamw_with_warm_up_cosine_scheduler(
         weight_decay: float = 1e-1,
         exponent: float = 1.0,
         gradient_accumulation_steps: int = 1,
+        warmup_steps: int = 500,
         mu_dtype: Optional[chex.ArrayDType] = None
 ):
     """
@@ -190,14 +191,15 @@ def get_adamw_with_warm_up_cosine_scheduler(
     :param weight_decay:
     :param exponent:
     :param gradient_accumulation_steps:
+    :param warmup_steps:
     :param mu_dtype:
     :return:
     """
     scheduler = optax.warmup_cosine_decay_schedule(
         init_value=0.5e-7,
         peak_value=learning_rate,
-        warmup_steps=steps,
-        decay_steps=steps + 1,
+        warmup_steps=warmup_steps,
+        decay_steps=steps,
         end_value=learning_rate,
         exponent=exponent
     )

--- a/src/fjformer/optimizers/adamw.py
+++ b/src/fjformer/optimizers/adamw.py
@@ -170,6 +170,7 @@ def get_adamw_with_warmup_linear_scheduler(
 def get_adamw_with_warm_up_cosine_scheduler(
         steps: int,
         learning_rate: float = 5e-5,
+        learning_rate_end: float = 1e-5,
         b1: float = 0.9,
         b2: float = 0.999,
         eps: float = 1e-8,
@@ -184,6 +185,7 @@ def get_adamw_with_warm_up_cosine_scheduler(
 
     :param steps:
     :param learning_rate:
+    :param learning_rate_end:
     :param b1:
     :param b2:
     :param eps:
@@ -200,7 +202,7 @@ def get_adamw_with_warm_up_cosine_scheduler(
         peak_value=learning_rate,
         warmup_steps=warmup_steps,
         decay_steps=steps,
-        end_value=learning_rate,
+        end_value=learning_rate_end,
         exponent=exponent
     )
     tx = optax.chain(

--- a/src/fjformer/optimizers/lion.py
+++ b/src/fjformer/optimizers/lion.py
@@ -158,6 +158,7 @@ def get_lion_with_warm_up_cosine_scheduler(
         b1: float = 0.9,
         b2: float = 0.99,
         gradient_accumulation_steps: int = 1,
+        warmup_steps: int = 500,
         mu_dtype: Optional[chex.ArrayDType] = None,
 ):
     """
@@ -168,14 +169,15 @@ def get_lion_with_warm_up_cosine_scheduler(
     :param b1:
     :param b2:
     :param gradient_accumulation_steps:
+    :param warmup_steps:
     :param mu_dtype:
     :return:
     """
     scheduler = optax.warmup_cosine_decay_schedule(
         init_value=0.5e-7,
         peak_value=learning_rate,
-        warmup_steps=steps,
-        decay_steps=steps + 1,
+        warmup_steps=warmup_steps,
+        decay_steps=steps,
         end_value=learning_rate,
         exponent=exponent,
     )

--- a/src/fjformer/optimizers/lion.py
+++ b/src/fjformer/optimizers/lion.py
@@ -154,6 +154,7 @@ def get_lion_with_cosine_scheduler(
 def get_lion_with_warm_up_cosine_scheduler(
         steps: int,
         learning_rate=5e-5,
+        learning_rate_end=1e-5,
         exponent: float = 1.0,
         b1: float = 0.9,
         b2: float = 0.99,
@@ -165,6 +166,7 @@ def get_lion_with_warm_up_cosine_scheduler(
 
     :param steps:
     :param learning_rate:
+    :param learning_rate_end:
     :param exponent:
     :param b1:
     :param b2:
@@ -178,7 +180,7 @@ def get_lion_with_warm_up_cosine_scheduler(
         peak_value=learning_rate,
         warmup_steps=warmup_steps,
         decay_steps=steps,
-        end_value=learning_rate,
+        end_value=learning_rate_end,
         exponent=exponent,
     )
     tx = optax.chain(

--- a/src/fjformer/optimizers/rmsprop.py
+++ b/src/fjformer/optimizers/rmsprop.py
@@ -209,6 +209,7 @@ def get_rmsprop_with_warmup_linear_scheduler(
 def get_rmsprop_with_warm_up_cosine_scheduler(
         steps: int,
         learning_rate: float = 5e-5,
+        learning_rate_end: float = 1e-5,
         decay: float = 0.9,
         initial_scale: float = 0.,
         momentum: Optional[float] = None,
@@ -226,6 +227,7 @@ def get_rmsprop_with_warm_up_cosine_scheduler(
 
     :param steps: int: Define the number of steps in the warm up phase
     :param learning_rate: float: Set the learning rate of the optimizer
+    :param learning_rate_end: float: Set the final learning rate of the optimizer after decay
     :param decay: float: Control the decay rate of the rmsprop algorithm
     :param initial_scale: float: Scale the initial gradient
     :param momentum: Optional[float]: Define the momentum of the optimizer
@@ -243,7 +245,7 @@ def get_rmsprop_with_warm_up_cosine_scheduler(
         peak_value=learning_rate,
         warmup_steps=warmup_steps,
         decay_steps=steps,
-        end_value=learning_rate,
+        end_value=learning_rate_end,
         exponent=exponent
     )
 

--- a/src/fjformer/optimizers/rmsprop.py
+++ b/src/fjformer/optimizers/rmsprop.py
@@ -217,6 +217,7 @@ def get_rmsprop_with_warm_up_cosine_scheduler(
         weight_decay: float = 1e-1,
         exponent: float = 1.0,
         gradient_accumulation_steps: int = 1,
+        warmup_steps: int = 500,
 ):
     """
     The get_rmsprop_with_warm_up_cosine_scheduler function returns a tuple of two objects:
@@ -233,14 +234,15 @@ def get_rmsprop_with_warm_up_cosine_scheduler(
     :param weight_decay: float: Add a weight decay to the loss function
     :param exponent: float: Control the shape of the cosine curve
     :param gradient_accumulation_steps: int: Accumulate gradients over multiple batches
+    :param warmup_steps: int: Number of steps of the linear warmup
     :param : Control the learning rate
     :return: Optimizer,Scheduler
     """
     scheduler = optax.warmup_cosine_decay_schedule(
         init_value=0.5e-7,
         peak_value=learning_rate,
-        warmup_steps=steps,
-        decay_steps=steps + 1,
+        warmup_steps=warmup_steps,
+        decay_steps=steps,
         end_value=learning_rate,
         exponent=exponent
     )


### PR DESCRIPTION
I've been training LLMs with EasyDeL and noticed that my learning rates aren't warming up and decaying properly when using the Cosine with Linear Warmup scheduler (it is always warming up and never decaying). Looks like this should fix it.

Reference: [Optax Docs](https://optax.readthedocs.io/en/latest/api/optimizer_schedules.html#optax.warmup_cosine_decay_schedule)